### PR TITLE
Integrate Bluetooth TX flow with basic web UI

### DIFF
--- a/bluetooth-wallet.js
+++ b/bluetooth-wallet.js
@@ -1,111 +1,176 @@
 // File: bluetooth-wallet.js
 
 // Import ecash-lib (assuming it's included in window.ecashlib)
-const { Wallet } = window.ecashlib;
-const chronik = new window.ChronikClient("https://chronik.e.cash");
+const { Wallet, Script } = window.ecashlib;
+const chronik = new window.ChronikClient('https://chronik.e.cash');
 
+// Wallet instance shared by all actions
 let currentWallet = null;
+let lastHandshakeAddress = null;
 
 // ======= 1. Build Raw Transaction Locally =======
 async function createRawTransaction(toAddress, amountSats, tokenId = null, tokenAmount = null) {
-    await currentWallet.sync();
+  // Validate destination address as a basic handshake/validation
+  Script.fromAddress(toAddress);
 
-    const outputs = [
-        { to: toAddress, sats: amountSats }
-    ];
+  await currentWallet.sync();
 
-    const tokenActions = tokenId ? [
+  const outputs = [{ to: toAddress, sats: amountSats }];
+
+  const tokenActions = tokenId
+    ? [
         {
-            type: 'SEND',
-            tokenId,
-            tokenType: window.ecashlib.SLP_TOKEN_TYPE_FUNGIBLE
-        }
-    ] : [];
+          type: 'SEND',
+          tokenId,
+          tokenType: window.ecashlib.SLP_TOKEN_TYPE_FUNGIBLE,
+        },
+      ]
+    : [];
 
-    const action = {
-        outputs,
-        tokenActions
-    };
+  const action = {
+    outputs,
+    tokenActions,
+  };
 
-    const builtTx = await currentWallet.action(action).build();
-    const rawTxHex = builtTx.toHex();
-    return rawTxHex;
+  const builtTx = await currentWallet.action(action).build();
+  return builtTx.toHex();
 }
 
 // ======= 2. Send Raw TX via Bluetooth =======
 async function sendTxViaBluetooth(rawTxHex) {
-    const options = {
-        acceptAllDevices: true,
-        optionalServices: ['0000ffe0-0000-1000-8000-00805f9b34fb'] // Example Service UUID
-    };
+  const options = {
+    acceptAllDevices: true,
+    optionalServices: ['0000ffe0-0000-1000-8000-00805f9b34fb'], // Example Service UUID
+  };
 
-    try {
-        const device = await navigator.bluetooth.requestDevice(options);
-        const server = await device.gatt.connect();
-        const service = await server.getPrimaryService('0000ffe0-0000-1000-8000-00805f9b34fb');
-        const characteristic = await service.getCharacteristic('0000ffe1-0000-1000-8000-00805f9b34fb');
+  try {
+    const device = await navigator.bluetooth.requestDevice(options);
+    const server = await device.gatt.connect();
+    const service = await server.getPrimaryService(
+      '0000ffe0-0000-1000-8000-00805f9b34fb',
+    );
+    const characteristic = await service.getCharacteristic(
+      '0000ffe1-0000-1000-8000-00805f9b34fb',
+    );
 
-        const encoder = new TextEncoder();
-        await characteristic.writeValue(encoder.encode(rawTxHex));
-        alert('Transaction sent via Bluetooth!');
+    const encoder = new TextEncoder();
+    // Handshake first
+    const handshake = JSON.stringify({
+      type: 'handshake',
+      address: currentWallet.address,
+    });
+    await characteristic.writeValue(encoder.encode(handshake));
 
-    } catch (error) {
-        console.error('Bluetooth Transmission Error:', error);
-        alert('Bluetooth error: ' + error);
-    }
+    // Small delay to allow the receiver to process the handshake
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Send the transaction payload
+    const payload = JSON.stringify({ type: 'tx', rawTx: rawTxHex });
+    await characteristic.writeValue(encoder.encode(payload));
+
+    alert('Transaction sent via Bluetooth!');
+  } catch (error) {
+    console.error('Bluetooth Transmission Error:', error);
+    alert('Bluetooth error: ' + error);
+  }
 }
 
 // ======= 3. Receive Raw TX via Bluetooth =======
 async function receiveTxViaBluetooth() {
-    const options = {
-        acceptAllDevices: true,
-        optionalServices: ['0000ffe0-0000-1000-8000-00805f9b34fb']
-    };
+  const options = {
+    acceptAllDevices: true,
+    optionalServices: ['0000ffe0-0000-1000-8000-00805f9b34fb'],
+  };
 
-    try {
-        const device = await navigator.bluetooth.requestDevice(options);
-        const server = await device.gatt.connect();
-        const service = await server.getPrimaryService('0000ffe0-0000-1000-8000-00805f9b34fb');
-        const characteristic = await service.getCharacteristic('0000ffe1-0000-1000-8000-00805f9b34fb');
+  try {
+    const device = await navigator.bluetooth.requestDevice(options);
+    const server = await device.gatt.connect();
+    const service = await server.getPrimaryService(
+      '0000ffe0-0000-1000-8000-00805f9b34fb',
+    );
+    const characteristic = await service.getCharacteristic(
+      '0000ffe1-0000-1000-8000-00805f9b34fb',
+    );
 
-        await characteristic.startNotifications();
-        characteristic.addEventListener('characteristicvaluechanged', (event) => {
-            const decoder = new TextDecoder();
-            const rawTxHex = decoder.decode(event.target.value);
-            alert('Received TX via Bluetooth:\n' + rawTxHex);
+    await characteristic.startNotifications();
+    characteristic.addEventListener('characteristicvaluechanged', (event) => {
+      const decoder = new TextDecoder();
+      const msg = decoder.decode(event.target.value);
 
-            // Store to localStorage for broadcasting later
-            localStorage.setItem('pendingRawTx', rawTxHex);
-        });
+      try {
+        const data = JSON.parse(msg);
+        if (data.type === 'handshake') {
+          try {
+            Script.fromAddress(data.address);
+            lastHandshakeAddress = data.address;
+            alert('Handshake received from ' + data.address);
+          } catch (e) {
+            console.warn('Invalid handshake address');
+          }
+          return;
+        }
 
-        alert('Waiting for transaction via Bluetooth...');
+        if (data.type === 'tx') {
+          if (!lastHandshakeAddress) {
+            console.warn('No handshake. Ignoring tx');
+            return;
+          }
 
-    } catch (error) {
-        console.error('Bluetooth Reception Error:', error);
-        alert('Bluetooth error: ' + error);
-    }
+          const txs = JSON.parse(
+            localStorage.getItem('pendingRawTxs') || '[]',
+          );
+          txs.push({ from: lastHandshakeAddress, rawTx: data.rawTx });
+          localStorage.setItem('pendingRawTxs', JSON.stringify(txs));
+          alert('Received TX via Bluetooth from ' + lastHandshakeAddress);
+          lastHandshakeAddress = null;
+        }
+      } catch (err) {
+        console.error('Invalid message', err);
+      }
+    });
+
+    alert('Waiting for transaction via Bluetooth...');
+  } catch (error) {
+    console.error('Bluetooth Reception Error:', error);
+    alert('Bluetooth error: ' + error);
+  }
 }
 
 // ======= 4. Broadcast TX to eCash Network =======
-async function broadcastStoredTx() {
-    const rawTxHex = localStorage.getItem('pendingRawTx');
-    if (!rawTxHex) {
-        alert('No transaction stored. Receive one via Bluetooth first.');
-        return;
-    }
+async function broadcastStoredTxs() {
+  const stored = JSON.parse(localStorage.getItem('pendingRawTxs') || '[]');
+  if (stored.length === 0) {
+    alert('No transactions stored. Receive one via Bluetooth first.');
+    return;
+  }
 
+  const remaining = [];
+  for (const tx of stored) {
     try {
-        await chronik.broadcastTx(rawTxHex);
-        alert('Transaction broadcasted successfully!');
-        localStorage.removeItem('pendingRawTx');
+      await chronik.broadcastTx(tx.rawTx);
     } catch (error) {
-        console.error('Broadcast Error:', error);
-        alert('Broadcast failed: ' + error);
+      console.error('Broadcast Error:', error);
+      remaining.push(tx); // keep tx for retry
     }
+  }
+
+  localStorage.setItem('pendingRawTxs', JSON.stringify(remaining));
+  alert(
+    `Broadcasted ${stored.length - remaining.length} tx(s); ${remaining.length} remaining`,
+  );
 }
 
 // ======= Wallet Initialization from Mnemonic =======
-async function connectMnemonic(mnemonic) {
-    currentWallet = await Wallet.fromSeed(mnemonic);
-    alert('Wallet connected!');
+async function initWallet(mnemonic) {
+  currentWallet = Wallet.fromMnemonic(mnemonic, chronik);
+  await currentWallet.sync();
+  alert('Wallet connected!');
+  return currentWallet.address;
 }
+
+// Expose functions globally for UI integration
+window.initWallet = initWallet;
+window.createRawTransaction = createRawTransaction;
+window.sendTxViaBluetooth = sendTxViaBluetooth;
+window.receiveTxViaBluetooth = receiveTxViaBluetooth;
+window.broadcastStoredTxs = broadcastStoredTxs;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>XEC Bluetooth Wallet</title>
+</head>
+<body>
+  <h1>XEC Bluetooth Wallet</h1>
+  <section>
+    <h2>Initialize Wallet</h2>
+    <textarea id="mnemonic" placeholder="Mnemonic" rows="2" cols="60"></textarea><br />
+    <button id="init">Init Wallet</button>
+    <div id="address"></div>
+  </section>
+
+  <section>
+    <h2>Send Transaction</h2>
+    <input id="to" placeholder="Destination address" size="60" />
+    <input id="amount" type="number" placeholder="Satoshis" />
+    <button id="send">Send via Bluetooth</button>
+  </section>
+
+  <section>
+    <h2>Receive / Broadcast</h2>
+    <button id="receive">Receive TX via Bluetooth</button>
+    <button id="broadcast">Broadcast Stored TXs</button>
+  </section>
+
+  <pre id="log"></pre>
+
+  <script src="https://unpkg.com/ecash-lib@1.0.3/dist/index.umd.js"></script>
+  <script src="https://unpkg.com/chronik-client@0.6.19/dist/index.umd.js"></script>
+  <script src="./bluetooth-wallet.js"></script>
+  <script>
+    const logEl = document.getElementById('log');
+    const log = (msg) => (logEl.textContent += msg + '\n');
+
+    document.getElementById('init').addEventListener('click', async () => {
+      const mnemonic = document.getElementById('mnemonic').value.trim();
+      if (!mnemonic) return alert('Provide mnemonic');
+      try {
+        const addr = await initWallet(mnemonic);
+        document.getElementById('address').textContent = 'Address: ' + addr;
+        log('Wallet initialized');
+      } catch (e) {
+        log('Init error: ' + e.message);
+      }
+    });
+
+    document.getElementById('send').addEventListener('click', async () => {
+      const to = document.getElementById('to').value.trim();
+      const amt = document.getElementById('amount').value;
+      if (!to || !amt) return alert('Provide destination and amount');
+      try {
+        const rawTx = await createRawTransaction(to, BigInt(amt));
+        await sendTxViaBluetooth(rawTx);
+        log('TX built and sent');
+      } catch (e) {
+        log('Send error: ' + e.message);
+      }
+    });
+
+    document.getElementById('receive').addEventListener('click', async () => {
+      try {
+        await receiveTxViaBluetooth();
+        log('Listening for TX');
+      } catch (e) {
+        log('Receive error: ' + e.message);
+      }
+    });
+
+    document.getElementById('broadcast').addEventListener('click', async () => {
+      try {
+        await broadcastStoredTxs();
+        log('Broadcast attempt finished');
+      } catch (e) {
+        log('Broadcast error: ' + e.message);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add handshake and multi-TX handling to Bluetooth wallet logic
- Expose wallet init and Bluetooth helpers globally
- Create browser UI with buttons to init wallet, send/receive via Bluetooth and broadcast stored TXs

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890b90b64f883328c2dda4c15b4b71d